### PR TITLE
Correct X-Forwarded-For handling

### DIFF
--- a/pbnh/views.py
+++ b/pbnh/views.py
@@ -66,12 +66,7 @@ def create_paste() -> tuple[dict[str, str], int]:
     try:
         with db.paster_context() as paster:
             hashid = paster.create(
-                data,
-                mime=mime,
-                # If the request was forwarded from a reverse proxy (e.g. nginx)
-                # request.remote_addr is the proxy, not the client:
-                ip=request.headers.get("X-Forwarded-For", request.remote_addr),
-                sunset=sunset,
+                data, mime=mime, ip=request.remote_addr, sunset=sunset
             )
     except db.HashCollision as exc:
         hashid = str(exc)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -109,6 +109,8 @@ def test_proxy_fix(app):
         )
         return urlsplit(json.loads(response.data.decode("utf-8"))["link"]).scheme
 
-    assert _proto_forwarded_link_scheme(app) == "http"
-    app.config["WERKZEUG_PROXY_FIX"] = {"x_proto": 1}
-    assert _proto_forwarded_link_scheme(pbnh.create_app(app.config)) == "https"
+    for x_proto, scheme in {0: "http", 1: "https"}.items():
+        app.config["WERKZEUG_PROXY_FIX"] = {"x_proto": x_proto}
+        assert (
+            _proto_forwarded_link_scheme(pbnh.create_app(app.config)) == scheme
+        ), x_proto


### PR DESCRIPTION
#2 integrated `werkzeug.middleware.proxy_fix.ProxyFix`, [which adjusts `request.remote_addr` automatically](https://github.com/pallets/werkzeug/blob/92c6380248c7272ee668e1f8bbd80447027ccce2/src/werkzeug/middleware/proxy_fix.py#L147-L149).

That means the custom `X-Forwarded-For` handling in `pbnh/views.py` is not only unnecessary, it actually _bypasses_ the protection of setting `ProxyFix(x_for=0)` (or just omitting `WERKZEUG_PROXY_FIX` in the config)! In fact, the custom handling is a "vulnerability" when running PBNH without a reverse proxy (which _shouldn't_ be done in production anyways, but still).
- Note: There are scare quotes around "vulnerability" because the actual effect of exploiting it is that the wrong client IP gets put into the DB, which is bad for audit, but doesn't necessarily compromise the app per se.