### PR TITLE
Retry the database check if it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,27 @@ docker run --interactive --tty \
 If the database is not initialized correctly, the server will produce an error like this:
 
 ```
-[2023-02-28 07:13:52 +0000] [7] [INFO] /etc/pbnh.yaml was loaded successfully.
-[2023-02-28 07:13:52 +0000] [7] [ERROR] (sqlite3.OperationalError) no such table: paste
+[2023-04-16 19:04:25 +0000] [1] [INFO] Starting gunicorn 20.1.0
+[2023-04-16 19:04:25 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
+[2023-04-16 19:04:25 +0000] [1] [INFO] Using worker: sync
+[2023-04-16 19:04:25 +0000] [7] [INFO] Booting worker with pid: 7
+[2023-04-16 19:04:26 +0000] [7] [INFO] PBNH_CONFIG is not set in the environment. Trying /etc/pbnh.yaml...
+[2023-04-16 19:04:26 +0000] [7] [INFO] /etc/pbnh.yaml was loaded successfully.
+[2023-04-16 19:04:26 +0000] [7] [ERROR] (sqlite3.OperationalError) no such table: paste
 [SQL: SELECT paste.id AS paste_id, paste.hashid AS paste_hashid, paste.ip AS paste_ip, paste.timestamp AS paste_timestamp, paste.mime AS paste_mime, paste.sunset AS paste_sunset, paste.data AS paste_data
 FROM paste
 WHERE paste.hashid = ?
  LIMIT ? OFFSET ?]
 [parameters: ('Has the database been initialized?', 1, 0)]
-(Background on this error at: https://sqlalche.me/e/14/e3q8)
-Failed to find application object: 'create_app(check_db=True)'
-[2023-02-28 07:13:52 +0000] [7] [INFO] Worker exiting (pid: 7)
-[2023-02-28 07:13:53 +0000] [1] [INFO] Shutting down: Master
-[2023-02-28 07:13:53 +0000] [1] [INFO] Reason: App failed to load.
+(Background on this error at: https://sqlalche.me/e/20/e3q8)
+[2023-04-16 19:04:26 +0000] [7] [INFO] The database is not usable. Trying again in 10 seconds...
+```
+
+Note: If this happens, the container will remain running so that it can be used to initialize the database:
+
+``` sh
+docker ps  # Get the container name or ID.
+docker exec "$container_name_or_ID" pipenv run flask --app pbnh db init
 ```
 
 ### Execution

--- a/pbnh/__init__.py
+++ b/pbnh/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import time
 from typing import Any
 
 from flask import Flask
@@ -67,7 +68,7 @@ def create_app(
     app.register_blueprint(pbnh.views.blueprint)
 
     # Ensure the DB is accessible.
-    if check_db:
+    while check_db:
         import pbnh.db
 
         with app.app_context():
@@ -76,6 +77,12 @@ def create_app(
                     paster.query(hashid="Has the database been initialized?")
             except Exception as exc:
                 app.logger.error(exc)
-                return None
+                secs = 10
+                app.logger.info(
+                    f"The database is not usable. Trying again in {secs} seconds..."
+                )
+                time.sleep(secs)
+            else:
+                check_db = False
 
     return app

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,9 +12,18 @@ def test_create_app_check_db(app):
     assert pbnh.create_app(app.config, check_db=True)
 
 
-def test_create_app_check_db_fails(override_config):
+def test_create_app_check_db_fails(override_config, monkeypatch):
     """Passing check_db to create_app fails if the DB is not initialized."""
-    assert pbnh.create_app(override_config, check_db=True) is None
+
+    class _TestDBCheckFailedError(Exception):
+        pass
+
+    def _fake_sleep(*args, **kwargs):
+        raise _TestDBCheckFailedError
+
+    monkeypatch.setattr(pbnh.time, "sleep", _fake_sleep)
+    with pytest.raises(_TestDBCheckFailedError):
+        pbnh.create_app(override_config, check_db=True)
 
 
 def test_config_nondebug(override_config):


### PR DESCRIPTION
If the app is running in a container and the database check fails, the container will exit. Production deployments may automatically try to restart the container; however, that will also fail unless the database has been initialized. The easiest way to initialize the database may be to `exec` the init command in the container, though, which will not work unless the container is running.

This keeps the container running and re-checking the database every 10 seconds, which should allow the container to be used for initialization without bombarding the database.