### PR TITLE
Redirect to a raw txt retrieval from the Web UI

### DIFF
--- a/pbnh/templates/index.html
+++ b/pbnh/templates/index.html
@@ -5,7 +5,7 @@ saveicon.addEventListener('click', function () {
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
         if (xhttp.readyState == 4 && xhttp.status == 201 && xhttp.responseText.length) {
-            window.location.href = JSON.parse(xhttp.responseText).link;
+            window.location.href = JSON.parse(xhttp.responseText).link + ".txt";
         }
     };
     var myForm = new FormData();


### PR DESCRIPTION
Currently we redirect to a Web render;
however, if libmagic guesses a type that the browser cannot render, the browser will try to download the paste,
which makes it difficult to get a link to the paste.

This makes it so the Web UI redirects to a raw txt render. The user can make it prettier my manually adjusting the URL if they choose.