### PR TITLE
Fix a bug in extensionless raw retrieval

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   db:
     image: postgres:9.6

--- a/pbnh/views.py
+++ b/pbnh/views.py
@@ -251,7 +251,7 @@ def redirect_to_raw(hashid: str, mode: str = "") -> flask.typing.ResponseReturnV
         "There is no extension associated with"
         f" the paste's media type ({paste['mime']}).",
     )
-    location = f"/{hashid}.{extension}"
+    location = f"/{hashid}{extension}"
     if mode:
         location += f"/{mode}"
     return redirect(location, 301)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -299,22 +299,32 @@ def test_post_collision(content_key, test_client):
     assert response.status_code == 409
 
 
-@pytest.fixture(params=[".", "/"])
-def delimiter(request):
-    return request.param
-
-
-def test_get_no_extension(content_key, test_client, delimiter):
+def test_get_no_extension_dot(content_key, test_client):
     response = test_client.post("/", data={content_key: "abc"})
     hashid = response.json["hashid"]
-    response = test_client.get(f"/{hashid}{delimiter}")
-    response.status_code == 301
-    response.location == f"/{hashid}{delimiter}txt"
+    response = test_client.get(f"/{hashid}.")
+    assert response.status_code == 301
+    assert response.location == f"/{hashid}.txt"
 
 
-def test_get_no_extension_unguessable(content_key, test_client, delimiter):
+def test_get_no_extension_slash(content_key, test_client):
+    response = test_client.post("/", data={content_key: "abc"})
+    hashid = response.json["hashid"]
+    response = test_client.get(f"/{hashid}/")
+    assert response.status_code == 301
+    assert response.location == f"/{hashid}/text"
+
+
+def test_get_no_extension_unguessable_dot(content_key, test_client):
     response = test_client.post("/", data={content_key: "abc", "mime": "fo/shizzle"})
     hashid = response.json["hashid"]
-    response = test_client.get(f"/{hashid}{delimiter}")
-    response.status_code == 302
-    response.location == f"/{hashid}"
+    response = test_client.get(f"/{hashid}.")
+    assert response.status_code == 422
+
+
+def test_get_no_extension_unguessable_slash(content_key, test_client):
+    response = test_client.post("/", data={content_key: "abc", "mime": "fo/shizzle"})
+    hashid = response.json["hashid"]
+    response = test_client.get(f"/{hashid}/")
+    assert response.status_code == 301
+    assert response.location == f"/{hashid}/raw"


### PR DESCRIPTION
Without this, fetching e.g. JSON data like
`GET /f3101f87224da22fc665d8a6fc893893054d7461.`
redirects to
`GET /f3101f87224da22fc665d8a6fc893893054d7461..json` (404)
but it is supposed to be
`GET /f3101f87224da22fc665d8a6fc893893054d7461.json`

This wasn't caught because the tests that cover it were missing `assert` keywords!