### PR TITLE
Use python:3.11-slim as the pbnh base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 # psycopg2: https://www.psycopg.org/docs/install.html#build-prerequisites
 # python-magic: https://github.com/ahupp/python-magic#debianubuntu
 RUN apt update && apt install --assume-yes \


### PR DESCRIPTION
Locally, this brought the image size from 1.22GB to 625MB.